### PR TITLE
docs: expand project readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,38 @@
-# Environment
+# MNPO Training Pipeline
 
-mnpo_train
-```shell
+This repository packages the full iterative **Multi-step Negative Preference Optimization (MNPO)** workflow that we used to fine-tune instruction-following language models with on-policy preference data. It bundles scripts for dataset preparation, preference data generation, reward model annotation, and multi-GPU MNPO training so you can reproduce or adapt our alignment pipeline end-to-end.
+
+## Key Features
+- **End-to-end alignment loop** – Automates dataset splitting, precomputation, MNPO training, and optional on-policy data refreshes across multiple iterations.
+- **Configurable infrastructure** – Includes ready-to-use Accelerate/DeepSpeed launch configs and per-iteration YAML training recipes targeting Gemma-2 instruction-tuned checkpoints.
+- **On-policy preference generation** – Provides decoding, post-processing, and reward-model scoring utilities for creating MNPO-ready binary preference datasets.
+- **Modular alignment utilities** – Reuses the shared `alignment` package for argument parsing, tokenizer handling, and adapter-aware checkpoint loading.
+
+## Repository Layout
+
+| Path | Description |
+| --- | --- |
+| `mnpo_scripts/` | MNPO orchestration code: configuration dataclasses, precomputation loop, MNPO trainer, and CLI entrypoints such as `run_mnpo.py` and `split_dataset.py`. |
+| `on_policy_data_gen/` | Tools for generating and annotating on-policy preference pairs (decoding, post-processing, reward model annotation). |
+| `alignment/` | Shared alignment helpers for data loading, model utilities, and release tooling. |
+| `training_configs/` | MNPO hyperparameter YAMLs for each training stage (e.g., `gemma-2-9b-it-mnpo-iter*.yaml`). |
+| `accelerate_configs/` | Launch configurations for Accelerate, DeepSpeed ZeRO, and FSDP setups. |
+| `scripts/` | Auxiliary utilities and launch helpers. |
+| `run.sh` | Example shell pipeline that ties together dataset splitting, on-policy data refresh, precomputation, and training loops. |
+
+## Environment Setup
+We separate environments for model training and large-scale decoding. Both assume **Python 3.10** and CUDA 12.8 builds of PyTorch/FlashAttention.
+
+<details>
+<summary><code>mnpo_train</code> (training & reward model inference)</summary>
+
+```bash
 conda create -n mnpo_train python=3.10 -y
 conda activate mnpo_train
-pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/cu128
+pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 \
+    --index-url https://download.pytorch.org/whl/cu128
 pip install \
-  https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp310-cp310-linux_x86_64.whl  
+  https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp310-cp310-linux_x86_64.whl \
   numpy==1.26.4 \
   accelerate==0.29.2 \
   deepspeed==0.15.4 \
@@ -15,24 +41,59 @@ pip install \
   datasets==2.18.0 \
   huggingface-hub==0.23.2 \
   peft==0.7.1 \
-  wandb \
-
-
+  wandb
 ```
-mnpo_infer
+</details>
 
-```shell
+<details>
+<summary><code>mnpo_infer</code> (on-policy decoding)</summary>
+
+```bash
 conda create -n mnpo_infer python=3.10 -y
 conda activate mnpo_infer
+pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 \
+    --index-url https://download.pytorch.org/whl/cu128
 pip install \
-pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 --index-url https://download.pytorch.org/whl/cu128
   vllm==0.9.0 \
-  pip install "transformers<4.54.0"
+  "transformers<4.54.0" \
   datasets==2.18.0 \
-  https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp310-cp310-linux_x86_64.whl  
+  https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.0.post2/flash_attn-2.8.0.post2+cu12torch2.7cxx11abiFALSE-cp310-cp310-linux_x86_64.whl \
   numpy==1.26.4 \
   deepspeed==0.15.4 \
-  pip install https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.5%2Bcu128torch2.7-cp38-abi3-linux_x86_64.whl \
+  https://download.pytorch.org/whl/cu128/flashinfer/flashinfer_python-0.2.5%2Bcu128torch2.7-cp38-abi3-linux_x86_64.whl \
   more_itertools
-
 ```
+</details>
+
+Set `PYTHONPATH` to the repository root before running any module entrypoints:
+
+```bash
+export PYTHONPATH=$(pwd)
+```
+
+## End-to-End Workflow
+The `run.sh` script demonstrates a three-iteration MNPO curriculum and can be adapted to your infrastructure.
+
+1. **Initial dataset split** – `mnpo_scripts.split_dataset` shards the base preference dataset into per-iteration train/test JSONL files to avoid leakage between stages.
+2. **On-policy generation (optional for iteration &gt; 1)** – `on_policy_data_gen.decode` samples multiple responses per prompt, `post_process` filters identical answers, and `reward_model_annotate` scores them with a reward model to produce MNPO-ready pairs.
+3. **Precomputation** – `mnpo_scripts.precompute` computes log-probabilities, normalizers, and history buffers used by MNPO training. Previous stage checkpoints can be chained via the `--history_paths` argument.
+4. **Training** – `mnpo_scripts.run_mnpo` launches the actual MNPO updates using Accelerate/DeepSpeed and the YAML config for the current iteration. Outputs are written under `outputs/` and fed into the next iteration.
+
+Adjust the variables at the top of `run.sh` (base model, dataset name, GPU count, cache directories) to reflect your setup, then execute:
+
+```bash
+bash run.sh
+```
+
+## Configuration Notes
+- **Training configs** – Each YAML file in `training_configs/` encodes optimizer parameters, dataset paths, and logging options for a specific iteration. Modify them to switch base checkpoints or learning schedules.
+- **Accelerate/DeepSpeed** – Choose the launch strategy that matches your cluster by supplying one of the configs in `accelerate_configs/` to `accelerate launch` (e.g., ZeRO-3 or FSDP).
+- **Reward model** – Update the default reward model in `on_policy_data_gen/reward_model_annotate.py` if you want to score generations with a different checkpoint.
+
+## Extending the Pipeline
+- Implement custom preprocessing or filtering by editing `alignment/data.py` before the MNPO precomputation stage.
+- Add new iterative stages by creating additional training configs and updating the iteration loop in `run.sh`.
+- Swap in alternative base models by adjusting `BASE_MODEL` and ensuring tokenization/chat template support in `mnpo_scripts/run_mnpo.py`.
+
+## Support & Citation
+If you build on this codebase in academic work, please cite the MNPO methodology and link back to this repository so others can reproduce your setup.


### PR DESCRIPTION
## Summary
- replace the minimal README with an overview of the MNPO training pipeline
- document repository layout, environment setup, and the iterative workflow driven by `run.sh`
- add configuration tips for extending or customizing the alignment stages

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d79db983ac832bb43b38df6316ca0f